### PR TITLE
MVP: Poland JDG tax calculator (React + TypeScript, 2026)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,12 @@
----
-layout: presentation
----
-
-{% for post in site.posts reversed %}
-	{% include slide.html %}
-	<div class="page-break"></div>
-{% endfor %}
-{% unless site.simple-slideshow %}
-{% if site.overview %}
-<section id="overview" class="step" {% for attr in site.overview-data %} data-{{attr[0]}}="{{attr[1]}}"{% endfor %}></section>
-{% endif %}
-{% endunless %}
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Poland JDG Tax Calculator (2026)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "poland-jdg-tax-calculator",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.2",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.8",
+    "vitest": "^2.1.1"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,153 +9,73 @@ type Copy = {
   subtitle: string;
   language: string;
   taxMode: string;
-  annualRevenue: string;
-  annualCosts: string;
+  monthlyRevenue: string;
+  monthlyCosts: string;
+  includeZus: string;
   ryczaltRate: string;
   estimate: string;
-  taxableBase: string;
-  estimatedAnnualTax: string;
+  monthlyTaxableBase: string;
+  monthlyTax: string;
+  monthlyZus: string;
+  monthlyTotal: string;
+  annualTax: string;
+  annualZus: string;
+  annualTotal: string;
   effectiveTaxRate: string;
   disclaimer: string;
 };
 
 const I18N: Record<Language, Copy> = {
   pl: {
-    title: 'Kalkulator podatku JDG w Polsce (2026)',
-    subtitle: 'MVP dla B2B / jednoosobowej działalności gospodarczej.',
-    language: 'Język',
-    taxMode: 'Forma opodatkowania',
-    annualRevenue: 'Roczny przychód (PLN)',
-    annualCosts: 'Roczne koszty (PLN)',
-    ryczaltRate: 'Stawka ryczałtu',
-    estimate: 'Szacunek',
-    taxableBase: 'Podstawa opodatkowania',
-    estimatedAnnualTax: 'Szacowany roczny podatek',
-    effectiveTaxRate: 'Efektywna stopa podatku',
-    disclaimer: 'Zastrzeżenie: Ten kalkulator przedstawia wyłącznie szacunek i nie stanowi porady prawnej ani podatkowej.'
+    title: 'Kalkulator podatku JDG w Polsce (2026)', subtitle: 'Kalkulacja miesięczna + roczna dla B2B / JDG.', language: 'Język', taxMode: 'Forma opodatkowania', monthlyRevenue: 'Miesięczny przychód (PLN)', monthlyCosts: 'Miesięczne koszty (PLN)', includeZus: 'Uwzględnij ZUS', ryczaltRate: 'Stawka ryczałtu', estimate: 'Szacunek', monthlyTaxableBase: 'Miesięczna podstawa opodatkowania', monthlyTax: 'Szacowany podatek miesięczny', monthlyZus: 'ZUS miesięczny', monthlyTotal: 'Łączne obciążenie miesięczne', annualTax: 'Szacowany podatek roczny', annualZus: 'ZUS roczny', annualTotal: 'Łączne obciążenie roczne', effectiveTaxRate: 'Efektywna stopa obciążeń', disclaimer: 'Zastrzeżenie: Ten kalkulator przedstawia wyłącznie szacunek i nie stanowi porady prawnej ani podatkowej.'
   },
   en: {
-    title: 'Poland JDG Tax Calculator (2026)',
-    subtitle: 'MVP for B2B / sole proprietorship (JDG).',
-    language: 'Language',
-    taxMode: 'Tax mode',
-    annualRevenue: 'Annual revenue (PLN)',
-    annualCosts: 'Annual costs (PLN)',
-    ryczaltRate: 'Ryczałt rate',
-    estimate: 'Estimate',
-    taxableBase: 'Taxable base',
-    estimatedAnnualTax: 'Estimated annual tax',
-    effectiveTaxRate: 'Effective tax rate',
-    disclaimer: 'Disclaimer: This calculator provides an estimate only and does not constitute legal or tax advice.'
+    title: 'Poland JDG Tax Calculator (2026)', subtitle: 'Monthly + annual estimate for B2B / sole proprietorship (JDG).', language: 'Language', taxMode: 'Tax mode', monthlyRevenue: 'Monthly revenue (PLN)', monthlyCosts: 'Monthly costs (PLN)', includeZus: 'Include ZUS', ryczaltRate: 'Ryczałt rate', estimate: 'Estimate', monthlyTaxableBase: 'Monthly taxable base', monthlyTax: 'Estimated monthly tax', monthlyZus: 'Monthly ZUS', monthlyTotal: 'Monthly total burden', annualTax: 'Estimated annual tax', annualZus: 'Annual ZUS', annualTotal: 'Annual total burden', effectiveTaxRate: 'Effective burden rate', disclaimer: 'Disclaimer: This calculator provides an estimate only and does not constitute legal or tax advice.'
   },
   ru: {
-    title: 'Калькулятор налога JDG в Польше (2026)',
-    subtitle: 'MVP для B2B / индивидуального предпринимателя (JDG).',
-    language: 'Язык',
-    taxMode: 'Режим налогообложения',
-    annualRevenue: 'Годовая выручка (PLN)',
-    annualCosts: 'Годовые расходы (PLN)',
-    ryczaltRate: 'Ставка ryczałt',
-    estimate: 'Оценка',
-    taxableBase: 'Налоговая база',
-    estimatedAnnualTax: 'Оценочный годовой налог',
-    effectiveTaxRate: 'Эффективная ставка налога',
-    disclaimer: 'Дисклеймер: этот калькулятор дает только оценку и не является юридической или налоговой консультацией.'
+    title: 'Калькулятор налога JDG в Польше (2026)', subtitle: 'Помесячный и годовой расчет для B2B / ИП (JDG).', language: 'Язык', taxMode: 'Режим налогообложения', monthlyRevenue: 'Месячная выручка (PLN)', monthlyCosts: 'Месячные расходы (PLN)', includeZus: 'Учитывать ZUS', ryczaltRate: 'Ставка ryczałt', estimate: 'Оценка', monthlyTaxableBase: 'Месячная налоговая база', monthlyTax: 'Оценочный налог в месяц', monthlyZus: 'ZUS в месяц', monthlyTotal: 'Общая нагрузка в месяц', annualTax: 'Оценочный налог за год', annualZus: 'ZUS за год', annualTotal: 'Общая нагрузка за год', effectiveTaxRate: 'Эффективная ставка нагрузки', disclaimer: 'Дисклеймер: этот калькулятор дает только оценку и не является юридической или налоговой консультацией.'
   }
 };
 
-const TAX_MODE_LABELS: Record<Language, Record<TaxMode, string>> = {
-  pl: {
-    skala: 'skala podatkowa',
-    liniowy: 'podatek liniowy',
-    ryczalt: 'ryczałt ewidencjonowany'
-  },
-  en: {
-    skala: 'progressive tax scale',
-    liniowy: 'flat tax',
-    ryczalt: 'lump-sum tax (ryczałt)'
-  },
-  ru: {
-    skala: 'прогрессивная шкала',
-    liniowy: 'линейный налог',
-    ryczalt: 'упрощенный налог (ryczałt)'
-  }
-};
+const TAX_MODE_LABELS: Record<Language, Record<TaxMode, string>> = { pl: { skala: 'skala podatkowa', liniowy: 'podatek liniowy', ryczalt: 'ryczałt ewidencjonowany' }, en: { skala: 'progressive tax scale', liniowy: 'flat tax', ryczalt: 'lump-sum tax (ryczałt)' }, ru: { skala: 'прогрессивная шкала', liniowy: 'линейный налог', ryczalt: 'упрощенный налог (ryczałt)' } };
 
 const fmt = (value: number, language: Language): string =>
-  new Intl.NumberFormat(language === 'ru' ? 'ru-RU' : language === 'en' ? 'en-US' : 'pl-PL', {
-    style: 'currency',
-    currency: 'PLN',
-    maximumFractionDigits: 2
-  }).format(value);
+  new Intl.NumberFormat(language === 'ru' ? 'ru-RU' : language === 'en' ? 'en-US' : 'pl-PL', { style: 'currency', currency: 'PLN', maximumFractionDigits: 2 }).format(value);
 
 export function App() {
   const [language, setLanguage] = useState<Language>('pl');
   const [mode, setMode] = useState<TaxMode>('skala');
-  const [annualRevenue, setAnnualRevenue] = useState(250_000);
-  const [annualCosts, setAnnualCosts] = useState(50_000);
+  const [monthlyRevenue, setMonthlyRevenue] = useState(20_000);
+  const [monthlyCosts, setMonthlyCosts] = useState(4_000);
+  const [includeZus, setIncludeZus] = useState(true);
   const [ryczaltRateKey, setRyczaltRateKey] = useState<keyof typeof TAX_CONFIG_2026.ryczalt.rates>('default');
 
   const t = I18N[language];
-
-  const result = useMemo(
-    () => calculateTax({ annualRevenue, annualCosts, mode, ryczaltRateKey }),
-    [annualRevenue, annualCosts, mode, ryczaltRateKey]
-  );
+  const result = useMemo(() => calculateTax({ monthlyRevenue, monthlyCosts, mode, ryczaltRateKey, includeZus }), [monthlyRevenue, monthlyCosts, mode, ryczaltRateKey, includeZus]);
 
   return (
     <main className="container">
       <h1>{t.title}</h1>
       <p className="subtitle">{t.subtitle}</p>
-
       <section className="card form-grid">
-        <label>
-          {t.language}
-          <select value={language} onChange={(e) => setLanguage(e.target.value as Language)}>
-            <option value="pl">Polski</option>
-            <option value="en">English</option>
-            <option value="ru">Русский</option>
-          </select>
-        </label>
-
-        <label>
-          {t.taxMode}
-          <select value={mode} onChange={(e) => setMode(e.target.value as TaxMode)}>
-            <option value="skala">{TAX_MODE_LABELS[language].skala}</option>
-            <option value="liniowy">{TAX_MODE_LABELS[language].liniowy}</option>
-            <option value="ryczalt">{TAX_MODE_LABELS[language].ryczalt}</option>
-          </select>
-        </label>
-
-        <label>
-          {t.annualRevenue}
-          <input type="number" value={annualRevenue} onChange={(e) => setAnnualRevenue(Number(e.target.value))} min={0} />
-        </label>
-
-        <label>
-          {t.annualCosts}
-          <input type="number" value={annualCosts} onChange={(e) => setAnnualCosts(Number(e.target.value))} min={0} disabled={mode === 'ryczalt'} />
-        </label>
-
-        {mode === 'ryczalt' && (
-          <label>
-            {t.ryczaltRate}
-            <select value={ryczaltRateKey} onChange={(e) => setRyczaltRateKey(e.target.value as keyof typeof TAX_CONFIG_2026.ryczalt.rates)}>
-              {Object.entries(TAX_CONFIG_2026.ryczalt.rates).map(([key, rate]) => (
-                <option key={key} value={key}>{`${key} (${(rate * 100).toFixed(1)}%)`}</option>
-              ))}
-            </select>
-          </label>
-        )}
+        <label>{t.language}<select value={language} onChange={(e) => setLanguage(e.target.value as Language)}><option value="pl">Polski</option><option value="en">English</option><option value="ru">Русский</option></select></label>
+        <label>{t.taxMode}<select value={mode} onChange={(e) => setMode(e.target.value as TaxMode)}><option value="skala">{TAX_MODE_LABELS[language].skala}</option><option value="liniowy">{TAX_MODE_LABELS[language].liniowy}</option><option value="ryczalt">{TAX_MODE_LABELS[language].ryczalt}</option></select></label>
+        <label>{t.monthlyRevenue}<input type="number" value={monthlyRevenue} onChange={(e) => setMonthlyRevenue(Number(e.target.value))} min={0} /></label>
+        <label>{t.monthlyCosts}<input type="number" value={monthlyCosts} onChange={(e) => setMonthlyCosts(Number(e.target.value))} min={0} disabled={mode === 'ryczalt'} /></label>
+        <label><input type="checkbox" checked={includeZus} onChange={(e) => setIncludeZus(e.target.checked)} /> {t.includeZus}</label>
+        {mode === 'ryczalt' && <label>{t.ryczaltRate}<select value={ryczaltRateKey} onChange={(e) => setRyczaltRateKey(e.target.value as keyof typeof TAX_CONFIG_2026.ryczalt.rates)}>{Object.entries(TAX_CONFIG_2026.ryczalt.rates).map(([key, rate]) => <option key={key} value={key}>{`${key} (${(rate * 100).toFixed(1)}%)`}</option>)}</select></label>}
       </section>
-
       <section className="card results">
         <h2>{t.estimate}</h2>
-        <p>{t.taxableBase}: <strong>{fmt(result.taxableBase, language)}</strong></p>
-        <p>{t.estimatedAnnualTax}: <strong>{fmt(result.taxAmount, language)}</strong></p>
+        <p>{t.monthlyTaxableBase}: <strong>{fmt(result.monthlyTaxableBase, language)}</strong></p>
+        <p>{t.monthlyTax}: <strong>{fmt(result.monthlyTaxAmount, language)}</strong></p>
+        <p>{t.monthlyZus}: <strong>{fmt(result.monthlyZusAmount, language)}</strong></p>
+        <p>{t.monthlyTotal}: <strong>{fmt(result.monthlyTotalBurden, language)}</strong></p>
+        <p>{t.annualTax}: <strong>{fmt(result.annualTaxAmount, language)}</strong></p>
+        <p>{t.annualZus}: <strong>{fmt(result.annualZusAmount, language)}</strong></p>
+        <p>{t.annualTotal}: <strong>{fmt(result.annualTotalBurden, language)}</strong></p>
         <p>{t.effectiveTaxRate}: <strong>{(result.effectiveRate * 100).toFixed(2)}%</strong></p>
       </section>
-
       <p className="disclaimer">{t.disclaimer}</p>
     </main>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,68 @@
+import { useMemo, useState } from 'react';
+import { calculateTax } from './engine/taxEngine';
+import { TAX_CONFIG_2026, TaxMode } from './config/taxConfig2026';
+
+const fmt = (value: number): string =>
+  new Intl.NumberFormat('pl-PL', { style: 'currency', currency: 'PLN', maximumFractionDigits: 2 }).format(value);
+
+export function App() {
+  const [mode, setMode] = useState<TaxMode>('skala');
+  const [annualRevenue, setAnnualRevenue] = useState(250_000);
+  const [annualCosts, setAnnualCosts] = useState(50_000);
+  const [ryczaltRateKey, setRyczaltRateKey] = useState<keyof typeof TAX_CONFIG_2026.ryczalt.rates>('default');
+
+  const result = useMemo(
+    () => calculateTax({ annualRevenue, annualCosts, mode, ryczaltRateKey }),
+    [annualRevenue, annualCosts, mode, ryczaltRateKey]
+  );
+
+  return (
+    <main className="container">
+      <h1>Poland JDG Tax Calculator (2026)</h1>
+      <p className="subtitle">MVP for B2B / jednoosobowa działalność gospodarcza.</p>
+
+      <section className="card form-grid">
+        <label>
+          Tax mode
+          <select value={mode} onChange={(e) => setMode(e.target.value as TaxMode)}>
+            <option value="skala">skala podatkowa</option>
+            <option value="liniowy">podatek liniowy</option>
+            <option value="ryczalt">ryczałt ewidencjonowany</option>
+          </select>
+        </label>
+
+        <label>
+          Annual revenue (PLN)
+          <input type="number" value={annualRevenue} onChange={(e) => setAnnualRevenue(Number(e.target.value))} min={0} />
+        </label>
+
+        <label>
+          Annual costs (PLN)
+          <input type="number" value={annualCosts} onChange={(e) => setAnnualCosts(Number(e.target.value))} min={0} disabled={mode === 'ryczalt'} />
+        </label>
+
+        {mode === 'ryczalt' && (
+          <label>
+            Ryczałt rate
+            <select value={ryczaltRateKey} onChange={(e) => setRyczaltRateKey(e.target.value as keyof typeof TAX_CONFIG_2026.ryczalt.rates)}>
+              {Object.entries(TAX_CONFIG_2026.ryczalt.rates).map(([key, rate]) => (
+                <option key={key} value={key}>{`${key} (${(rate * 100).toFixed(1)}%)`}</option>
+              ))}
+            </select>
+          </label>
+        )}
+      </section>
+
+      <section className="card results">
+        <h2>Estimate</h2>
+        <p>Taxable base: <strong>{fmt(result.taxableBase)}</strong></p>
+        <p>Estimated annual tax: <strong>{fmt(result.taxAmount)}</strong></p>
+        <p>Effective tax rate: <strong>{(result.effectiveRate * 100).toFixed(2)}%</strong></p>
+      </section>
+
+      <p className="disclaimer">
+        Disclaimer: This calculator provides an estimate only and does not constitute legal or tax advice.
+      </p>
+    </main>
+  );
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,14 +2,101 @@ import { useMemo, useState } from 'react';
 import { calculateTax } from './engine/taxEngine';
 import { TAX_CONFIG_2026, TaxMode } from './config/taxConfig2026';
 
-const fmt = (value: number): string =>
-  new Intl.NumberFormat('pl-PL', { style: 'currency', currency: 'PLN', maximumFractionDigits: 2 }).format(value);
+type Language = 'pl' | 'en' | 'ru';
+
+type Copy = {
+  title: string;
+  subtitle: string;
+  language: string;
+  taxMode: string;
+  annualRevenue: string;
+  annualCosts: string;
+  ryczaltRate: string;
+  estimate: string;
+  taxableBase: string;
+  estimatedAnnualTax: string;
+  effectiveTaxRate: string;
+  disclaimer: string;
+};
+
+const I18N: Record<Language, Copy> = {
+  pl: {
+    title: 'Kalkulator podatku JDG w Polsce (2026)',
+    subtitle: 'MVP dla B2B / jednoosobowej działalności gospodarczej.',
+    language: 'Język',
+    taxMode: 'Forma opodatkowania',
+    annualRevenue: 'Roczny przychód (PLN)',
+    annualCosts: 'Roczne koszty (PLN)',
+    ryczaltRate: 'Stawka ryczałtu',
+    estimate: 'Szacunek',
+    taxableBase: 'Podstawa opodatkowania',
+    estimatedAnnualTax: 'Szacowany roczny podatek',
+    effectiveTaxRate: 'Efektywna stopa podatku',
+    disclaimer: 'Zastrzeżenie: Ten kalkulator przedstawia wyłącznie szacunek i nie stanowi porady prawnej ani podatkowej.'
+  },
+  en: {
+    title: 'Poland JDG Tax Calculator (2026)',
+    subtitle: 'MVP for B2B / sole proprietorship (JDG).',
+    language: 'Language',
+    taxMode: 'Tax mode',
+    annualRevenue: 'Annual revenue (PLN)',
+    annualCosts: 'Annual costs (PLN)',
+    ryczaltRate: 'Ryczałt rate',
+    estimate: 'Estimate',
+    taxableBase: 'Taxable base',
+    estimatedAnnualTax: 'Estimated annual tax',
+    effectiveTaxRate: 'Effective tax rate',
+    disclaimer: 'Disclaimer: This calculator provides an estimate only and does not constitute legal or tax advice.'
+  },
+  ru: {
+    title: 'Калькулятор налога JDG в Польше (2026)',
+    subtitle: 'MVP для B2B / индивидуального предпринимателя (JDG).',
+    language: 'Язык',
+    taxMode: 'Режим налогообложения',
+    annualRevenue: 'Годовая выручка (PLN)',
+    annualCosts: 'Годовые расходы (PLN)',
+    ryczaltRate: 'Ставка ryczałt',
+    estimate: 'Оценка',
+    taxableBase: 'Налоговая база',
+    estimatedAnnualTax: 'Оценочный годовой налог',
+    effectiveTaxRate: 'Эффективная ставка налога',
+    disclaimer: 'Дисклеймер: этот калькулятор дает только оценку и не является юридической или налоговой консультацией.'
+  }
+};
+
+const TAX_MODE_LABELS: Record<Language, Record<TaxMode, string>> = {
+  pl: {
+    skala: 'skala podatkowa',
+    liniowy: 'podatek liniowy',
+    ryczalt: 'ryczałt ewidencjonowany'
+  },
+  en: {
+    skala: 'progressive tax scale',
+    liniowy: 'flat tax',
+    ryczalt: 'lump-sum tax (ryczałt)'
+  },
+  ru: {
+    skala: 'прогрессивная шкала',
+    liniowy: 'линейный налог',
+    ryczalt: 'упрощенный налог (ryczałt)'
+  }
+};
+
+const fmt = (value: number, language: Language): string =>
+  new Intl.NumberFormat(language === 'ru' ? 'ru-RU' : language === 'en' ? 'en-US' : 'pl-PL', {
+    style: 'currency',
+    currency: 'PLN',
+    maximumFractionDigits: 2
+  }).format(value);
 
 export function App() {
+  const [language, setLanguage] = useState<Language>('pl');
   const [mode, setMode] = useState<TaxMode>('skala');
   const [annualRevenue, setAnnualRevenue] = useState(250_000);
   const [annualCosts, setAnnualCosts] = useState(50_000);
   const [ryczaltRateKey, setRyczaltRateKey] = useState<keyof typeof TAX_CONFIG_2026.ryczalt.rates>('default');
+
+  const t = I18N[language];
 
   const result = useMemo(
     () => calculateTax({ annualRevenue, annualCosts, mode, ryczaltRateKey }),
@@ -18,32 +105,41 @@ export function App() {
 
   return (
     <main className="container">
-      <h1>Poland JDG Tax Calculator (2026)</h1>
-      <p className="subtitle">MVP for B2B / jednoosobowa działalność gospodarcza.</p>
+      <h1>{t.title}</h1>
+      <p className="subtitle">{t.subtitle}</p>
 
       <section className="card form-grid">
         <label>
-          Tax mode
-          <select value={mode} onChange={(e) => setMode(e.target.value as TaxMode)}>
-            <option value="skala">skala podatkowa</option>
-            <option value="liniowy">podatek liniowy</option>
-            <option value="ryczalt">ryczałt ewidencjonowany</option>
+          {t.language}
+          <select value={language} onChange={(e) => setLanguage(e.target.value as Language)}>
+            <option value="pl">Polski</option>
+            <option value="en">English</option>
+            <option value="ru">Русский</option>
           </select>
         </label>
 
         <label>
-          Annual revenue (PLN)
+          {t.taxMode}
+          <select value={mode} onChange={(e) => setMode(e.target.value as TaxMode)}>
+            <option value="skala">{TAX_MODE_LABELS[language].skala}</option>
+            <option value="liniowy">{TAX_MODE_LABELS[language].liniowy}</option>
+            <option value="ryczalt">{TAX_MODE_LABELS[language].ryczalt}</option>
+          </select>
+        </label>
+
+        <label>
+          {t.annualRevenue}
           <input type="number" value={annualRevenue} onChange={(e) => setAnnualRevenue(Number(e.target.value))} min={0} />
         </label>
 
         <label>
-          Annual costs (PLN)
+          {t.annualCosts}
           <input type="number" value={annualCosts} onChange={(e) => setAnnualCosts(Number(e.target.value))} min={0} disabled={mode === 'ryczalt'} />
         </label>
 
         {mode === 'ryczalt' && (
           <label>
-            Ryczałt rate
+            {t.ryczaltRate}
             <select value={ryczaltRateKey} onChange={(e) => setRyczaltRateKey(e.target.value as keyof typeof TAX_CONFIG_2026.ryczalt.rates)}>
               {Object.entries(TAX_CONFIG_2026.ryczalt.rates).map(([key, rate]) => (
                 <option key={key} value={key}>{`${key} (${(rate * 100).toFixed(1)}%)`}</option>
@@ -54,15 +150,13 @@ export function App() {
       </section>
 
       <section className="card results">
-        <h2>Estimate</h2>
-        <p>Taxable base: <strong>{fmt(result.taxableBase)}</strong></p>
-        <p>Estimated annual tax: <strong>{fmt(result.taxAmount)}</strong></p>
-        <p>Effective tax rate: <strong>{(result.effectiveRate * 100).toFixed(2)}%</strong></p>
+        <h2>{t.estimate}</h2>
+        <p>{t.taxableBase}: <strong>{fmt(result.taxableBase, language)}</strong></p>
+        <p>{t.estimatedAnnualTax}: <strong>{fmt(result.taxAmount, language)}</strong></p>
+        <p>{t.effectiveTaxRate}: <strong>{(result.effectiveRate * 100).toFixed(2)}%</strong></p>
       </section>
 
-      <p className="disclaimer">
-        Disclaimer: This calculator provides an estimate only and does not constitute legal or tax advice.
-      </p>
+      <p className="disclaimer">{t.disclaimer}</p>
     </main>
   );
 }

--- a/src/config/taxConfig2026.ts
+++ b/src/config/taxConfig2026.ts
@@ -1,0 +1,21 @@
+export type TaxMode = 'skala' | 'liniowy' | 'ryczalt';
+
+export const TAX_CONFIG_2026 = {
+  skala: {
+    firstThreshold: 120_000,
+    firstRate: 0.12,
+    secondRate: 0.32,
+    kwotaWolna: 30_000
+  },
+  liniowy: {
+    rate: 0.19
+  },
+  ryczalt: {
+    rates: {
+      default: 0.12,
+      it: 0.12,
+      health: 0.14,
+      rental: 0.085
+    }
+  }
+} as const;

--- a/src/config/taxConfig2026.ts
+++ b/src/config/taxConfig2026.ts
@@ -17,5 +17,9 @@ export const TAX_CONFIG_2026 = {
       health: 0.14,
       rental: 0.085
     }
+  },
+  zus: {
+    monthlySocial: 1600,
+    monthlyHealth: 700
   }
 } as const;

--- a/src/engine/taxEngine.test.ts
+++ b/src/engine/taxEngine.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { calculateTax } from './taxEngine';
+
+describe('calculateTax', () => {
+  it('calculates skala podatkowa for income above threshold', () => {
+    const result = calculateTax({ mode: 'skala', annualRevenue: 300_000, annualCosts: 50_000 });
+    expect(result.taxableBase).toBe(220_000);
+    expect(result.taxAmount).toBeCloseTo(49_200, 2);
+  });
+
+  it('calculates podatek liniowy', () => {
+    const result = calculateTax({ mode: 'liniowy', annualRevenue: 300_000, annualCosts: 100_000 });
+    expect(result.taxableBase).toBe(200_000);
+    expect(result.taxAmount).toBeCloseTo(38_000, 2);
+  });
+
+  it('calculates ryczalt ewidencjonowany with selected rate', () => {
+    const result = calculateTax({ mode: 'ryczalt', annualRevenue: 200_000, annualCosts: 99_000, ryczaltRateKey: 'rental' });
+    expect(result.taxableBase).toBe(200_000);
+    expect(result.taxAmount).toBeCloseTo(17_000, 2);
+  });
+});

--- a/src/engine/taxEngine.test.ts
+++ b/src/engine/taxEngine.test.ts
@@ -2,21 +2,27 @@ import { describe, expect, it } from 'vitest';
 import { calculateTax } from './taxEngine';
 
 describe('calculateTax', () => {
-  it('calculates skala podatkowa for income above threshold', () => {
-    const result = calculateTax({ mode: 'skala', annualRevenue: 300_000, annualCosts: 50_000 });
-    expect(result.taxableBase).toBe(220_000);
-    expect(result.taxAmount).toBeCloseTo(49_200, 2);
+  it('calculates monthly skala podatkowa and includes ZUS', () => {
+    const result = calculateTax({ mode: 'skala', monthlyRevenue: 25_000, monthlyCosts: 4_000 });
+    expect(result.annualTaxableBase).toBe(222_000);
+    expect(result.annualTaxAmount).toBeCloseTo(49_840, 2);
+    expect(result.monthlyZusAmount).toBe(2_300);
+    expect(result.annualTotalBurden).toBeCloseTo(77_440, 2);
   });
 
-  it('calculates podatek liniowy', () => {
-    const result = calculateTax({ mode: 'liniowy', annualRevenue: 300_000, annualCosts: 100_000 });
-    expect(result.taxableBase).toBe(200_000);
-    expect(result.taxAmount).toBeCloseTo(38_000, 2);
+  it('calculates monthly podatek liniowy and includes ZUS', () => {
+    const result = calculateTax({ mode: 'liniowy', monthlyRevenue: 20_000, monthlyCosts: 5_000 });
+    expect(result.annualTaxableBase).toBe(180_000);
+    expect(result.annualTaxAmount).toBeCloseTo(34_200, 2);
+    expect(result.monthlyZusAmount).toBe(2_300);
+    expect(result.monthlyTotalBurden).toBeCloseTo(5_150, 2);
   });
 
-  it('calculates ryczalt ewidencjonowany with selected rate', () => {
-    const result = calculateTax({ mode: 'ryczalt', annualRevenue: 200_000, annualCosts: 99_000, ryczaltRateKey: 'rental' });
-    expect(result.taxableBase).toBe(200_000);
-    expect(result.taxAmount).toBeCloseTo(17_000, 2);
+  it('calculates monthly ryczalt with selected rate and optional no ZUS', () => {
+    const result = calculateTax({ mode: 'ryczalt', monthlyRevenue: 18_000, monthlyCosts: 2_000, ryczaltRateKey: 'rental', includeZus: false });
+    expect(result.annualTaxableBase).toBe(216_000);
+    expect(result.annualTaxAmount).toBeCloseTo(18_360, 2);
+    expect(result.annualZusAmount).toBe(0);
+    expect(result.monthlyTaxAmount).toBeCloseTo(1_530, 2);
   });
 });

--- a/src/engine/taxEngine.ts
+++ b/src/engine/taxEngine.ts
@@ -1,40 +1,41 @@
 import { TAX_CONFIG_2026, TaxMode } from '../config/taxConfig2026';
 
 export type TaxInput = {
-  annualRevenue: number;
-  annualCosts: number;
+  monthlyRevenue: number;
+  monthlyCosts: number;
   mode: TaxMode;
   ryczaltRateKey?: keyof typeof TAX_CONFIG_2026.ryczalt.rates;
+  includeZus?: boolean;
 };
 
 export type TaxResult = {
-  taxableBase: number;
-  taxAmount: number;
+  monthlyTaxableBase: number;
+  monthlyTaxAmount: number;
+  monthlyZusAmount: number;
+  monthlyTotalBurden: number;
+  annualTaxableBase: number;
+  annualTaxAmount: number;
+  annualZusAmount: number;
+  annualTotalBurden: number;
   effectiveRate: number;
 };
 
+const MONTHS_IN_YEAR = 12;
 const nonNegative = (value: number): number => Math.max(0, value);
 
-export const calculateTax = (input: TaxInput): TaxResult => {
-  if (input.mode === 'ryczalt') {
-    const rate = TAX_CONFIG_2026.ryczalt.rates[input.ryczaltRateKey ?? 'default'];
-    const taxableBase = nonNegative(input.annualRevenue);
-    const taxAmount = taxableBase * rate;
-    return {
-      taxableBase,
-      taxAmount,
-      effectiveRate: taxableBase > 0 ? taxAmount / taxableBase : 0
-    };
+const calculateAnnualIncomeTax = (mode: TaxMode, annualRevenue: number, annualCosts: number, ryczaltRateKey?: keyof typeof TAX_CONFIG_2026.ryczalt.rates): { taxableBase: number; taxAmount: number } => {
+  if (mode === 'ryczalt') {
+    const rate = TAX_CONFIG_2026.ryczalt.rates[ryczaltRateKey ?? 'default'];
+    const taxableBase = nonNegative(annualRevenue);
+    return { taxableBase, taxAmount: taxableBase * rate };
   }
 
-  const income = nonNegative(input.annualRevenue - input.annualCosts);
+  const income = nonNegative(annualRevenue - annualCosts);
 
-  if (input.mode === 'liniowy') {
-    const taxAmount = income * TAX_CONFIG_2026.liniowy.rate;
+  if (mode === 'liniowy') {
     return {
       taxableBase: income,
-      taxAmount,
-      effectiveRate: income > 0 ? taxAmount / income : 0
+      taxAmount: income * TAX_CONFIG_2026.liniowy.rate
     };
   }
 
@@ -42,11 +43,35 @@ export const calculateTax = (input: TaxInput): TaxResult => {
   const taxableAfterAllowance = nonNegative(income - kwotaWolna);
   const firstPart = Math.min(taxableAfterAllowance, firstThreshold - kwotaWolna);
   const secondPart = nonNegative(taxableAfterAllowance - firstPart);
-  const taxAmount = firstPart * firstRate + secondPart * secondRate;
 
   return {
     taxableBase: taxableAfterAllowance,
-    taxAmount,
-    effectiveRate: income > 0 ? taxAmount / income : 0
+    taxAmount: firstPart * firstRate + secondPart * secondRate
+  };
+};
+
+export const calculateTax = (input: TaxInput): TaxResult => {
+  const annualRevenue = nonNegative(input.monthlyRevenue) * MONTHS_IN_YEAR;
+  const annualCosts = nonNegative(input.monthlyCosts) * MONTHS_IN_YEAR;
+
+  const annualTax = calculateAnnualIncomeTax(input.mode, annualRevenue, annualCosts, input.ryczaltRateKey);
+
+  const monthlyZusAmount = input.includeZus === false ? 0 : TAX_CONFIG_2026.zus.monthlySocial + TAX_CONFIG_2026.zus.monthlyHealth;
+  const annualZusAmount = monthlyZusAmount * MONTHS_IN_YEAR;
+
+  const annualTotalBurden = annualTax.taxAmount + annualZusAmount;
+  const monthlyTaxAmount = annualTax.taxAmount / MONTHS_IN_YEAR;
+  const monthlyTaxableBase = annualTax.taxableBase / MONTHS_IN_YEAR;
+
+  return {
+    monthlyTaxableBase,
+    monthlyTaxAmount,
+    monthlyZusAmount,
+    monthlyTotalBurden: monthlyTaxAmount + monthlyZusAmount,
+    annualTaxableBase: annualTax.taxableBase,
+    annualTaxAmount: annualTax.taxAmount,
+    annualZusAmount,
+    annualTotalBurden,
+    effectiveRate: annualRevenue > 0 ? annualTotalBurden / annualRevenue : 0
   };
 };

--- a/src/engine/taxEngine.ts
+++ b/src/engine/taxEngine.ts
@@ -1,0 +1,52 @@
+import { TAX_CONFIG_2026, TaxMode } from '../config/taxConfig2026';
+
+export type TaxInput = {
+  annualRevenue: number;
+  annualCosts: number;
+  mode: TaxMode;
+  ryczaltRateKey?: keyof typeof TAX_CONFIG_2026.ryczalt.rates;
+};
+
+export type TaxResult = {
+  taxableBase: number;
+  taxAmount: number;
+  effectiveRate: number;
+};
+
+const nonNegative = (value: number): number => Math.max(0, value);
+
+export const calculateTax = (input: TaxInput): TaxResult => {
+  if (input.mode === 'ryczalt') {
+    const rate = TAX_CONFIG_2026.ryczalt.rates[input.ryczaltRateKey ?? 'default'];
+    const taxableBase = nonNegative(input.annualRevenue);
+    const taxAmount = taxableBase * rate;
+    return {
+      taxableBase,
+      taxAmount,
+      effectiveRate: taxableBase > 0 ? taxAmount / taxableBase : 0
+    };
+  }
+
+  const income = nonNegative(input.annualRevenue - input.annualCosts);
+
+  if (input.mode === 'liniowy') {
+    const taxAmount = income * TAX_CONFIG_2026.liniowy.rate;
+    return {
+      taxableBase: income,
+      taxAmount,
+      effectiveRate: income > 0 ? taxAmount / income : 0
+    };
+  }
+
+  const { firstThreshold, firstRate, secondRate, kwotaWolna } = TAX_CONFIG_2026.skala;
+  const taxableAfterAllowance = nonNegative(income - kwotaWolna);
+  const firstPart = Math.min(taxableAfterAllowance, firstThreshold - kwotaWolna);
+  const secondPart = nonNegative(taxableAfterAllowance - firstPart);
+  const taxAmount = firstPart * firstRate + secondPart * secondRate;
+
+  return {
+    taxableBase: taxableAfterAllowance,
+    taxAmount,
+    effectiveRate: income > 0 ? taxAmount / income : 0
+  };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+import './styles.css';
+
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,10 @@
+:root { font-family: Inter, system-ui, Arial, sans-serif; color: #102a43; background: #f5f7fb; }
+body { margin: 0; }
+.container { max-width: 760px; margin: 2rem auto; padding: 0 1rem; }
+.subtitle { color: #486581; margin-bottom: 1rem; }
+.card { background: white; border-radius: 12px; padding: 1rem; box-shadow: 0 2px 10px rgba(16,42,67,0.08); margin-bottom: 1rem; }
+.form-grid { display: grid; gap: 0.75rem; }
+label { display: grid; gap: 0.25rem; font-weight: 600; }
+input, select { padding: 0.55rem; border-radius: 8px; border: 1px solid #bcccdc; font-size: 1rem; }
+.results p { margin: 0.4rem 0; }
+.disclaimer { background: #fff4e5; border: 1px solid #ffd591; border-radius: 10px; padding: 0.75rem; color: #8a5a00; }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "moduleResolution": "Bundler",
+    "allowJs": false,
+    "strict": true,
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
### Motivation
- Provide a minimal, client-side JDG (B2B) tax calculator for Poland for year 2026 supporting the three requested taxation modes. 
- Keep tax constants and thresholds configurable and separate from calculation logic to make future updates safe and auditable. 
- Deliver a clean React+TypeScript UI with a clear visible disclaimer that results are estimates only.

### Description
- Add a Vite + React + TypeScript app shell and entrypoint with `src/main.tsx` and `index.html` for the client-only MVP. 
- Add `src/config/taxConfig2026.ts` containing all rates and thresholds (`skala`, `liniowy`, `ryczalt`) so values are not hardcoded in calculation functions. 
- Implement a separated calculation engine in `src/engine/taxEngine.ts` exposing `calculateTax` that computes tax for each mode using only values from the config. 
- Build a simple UI in `src/App.tsx` with inputs for revenue/costs, mode selection, ryczałt rate selector, results display, and a visible disclaimer, plus styling in `src/styles.css`. 
- Add unit tests covering each taxation mode in `src/engine/taxEngine.test.ts` and project tooling (`package.json`, `tsconfig.json`, `vite.config.ts`) configured for local dev and `vitest`.

### Testing
- Unit tests were added in `src/engine/taxEngine.test.ts` to cover `skala`, `liniowy`, and `ryczałt` calculation scenarios. 
- Automated install and test execution could not be completed in this environment because `npm install` failed due to registry access restrictions (HTTP 403), so `vitest` was not executed here. 
- The project is configured to run tests locally with `npm install` followed by `npm test` (which runs `vitest`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ce51f0efc832fa2abb665ada55912)