### PR TITLE
Add ZUS benefit selector to intro slide (Mały ZUS default)

### DIFF
--- a/_posts/0000-01-01-intro.md
+++ b/_posts/0000-01-01-intro.md
@@ -1,6 +1,17 @@
 ---
 layout: slide
-title: "Welcome to our slide deck!"
+title: "Калькулятор ZUS: выбор льготы"
 ---
 
-Use the right arrow to begin!
+В ZUS есть разные льготы — добавлен их выбор.
+
+<label for="zus-benefit">Выберите вашу льготу:</label>
+<select id="zus-benefit" name="zus-benefit">
+  <option value="small-zus" selected>Mały ZUS (малый ZUS)</option>
+  <option value="small-zus-plus">Mały ZUS Plus</option>
+  <option value="start-relief">Ulga na start</option>
+  <option value="preferential">Składki preferencyjne</option>
+  <option value="standard">Стандартный ZUS (без льгот)</option>
+</select>
+
+Сейчас выбран пример: **Mały ZUS (малый ZUS)**.


### PR DESCRIPTION
### Motivation
- Add a simple UI on the intro slide to allow selecting between different ZUS relief types and present `Mały ZUS` as the default example.

### Description
- Updated `_posts/0000-01-01-intro.md` to change the slide title to "Калькулятор ZUS: выбор льготы" and inserted a `<label>` and `<select>` containing options `small-zus` (Mały ZUS, selected), `small-zus-plus`, `start-relief`, `preferential`, and `standard`.

### Testing
- No automated tests were run for this content-only markdown/HTML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cfcb6d578832fa487acc4dcc3fae0)